### PR TITLE
fix(tex): fix formats and their selection based on alpha

### DIFF
--- a/include/btu/tex/formats.hpp
+++ b/include/btu/tex/formats.hpp
@@ -46,27 +46,19 @@ NLOHMANN_JSON_SERIALIZE_ENUM(TextureType,
                               {TextureType::Skin, "skin"},
                               {TextureType::EnvironmentMask, "environment_mask"}});
 
-enum class AllowCompressed : std::uint8_t
+struct GuessBestFormatArgs
 {
-    Yes,
-    No,
+    bool opaque_alpha     = false;
+    bool allow_compressed = true;
+    bool force_alpha      = false;
 };
 
-NLOHMANN_JSON_SERIALIZE_ENUM(AllowCompressed, {{AllowCompressed::Yes, "yes"}, {AllowCompressed::No, "no"}});
-
-enum class ForceAlpha : std::uint8_t
-{
-    Yes,
-    No
-};
-
-NLOHMANN_JSON_SERIALIZE_ENUM(ForceAlpha, {{ForceAlpha::Yes, "yes"}, {ForceAlpha::No, "no"}});
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GuessBestFormatArgs, opaque_alpha, allow_compressed, force_alpha);
 
 /// Based on https://forums.nexusmods.com/index.php?/topic/476227-skyrim-nif-files-with-underscores/
 auto guess_texture_type(std::u8string_view path) noexcept -> std::optional<TextureType>;
 
 auto guess_best_format(DXGI_FORMAT current_format,
                        BestFormatFor formats,
-                       AllowCompressed allow_compressed = AllowCompressed::Yes,
-                       ForceAlpha force_alpha           = ForceAlpha::No) noexcept -> DXGI_FORMAT;
+                       const GuessBestFormatArgs &guess_params) noexcept -> DXGI_FORMAT;
 } // namespace btu::tex

--- a/src/tex/formats.cpp
+++ b/src/tex/formats.cpp
@@ -44,13 +44,13 @@ auto guess_texture_type(std::u8string_view path) noexcept -> std::optional<Textu
 
 auto guess_best_format(const DXGI_FORMAT current_format,
                        const BestFormatFor formats,
-                       const AllowCompressed allow_compressed,
-                       const ForceAlpha force_alpha) noexcept -> DXGI_FORMAT
+                       const GuessBestFormatArgs &guess_params) noexcept -> DXGI_FORMAT
 {
     // allow compression if user requested it, or it was already compressed
-    const bool compressed = allow_compressed == AllowCompressed::Yes || DirectX::IsCompressed(current_format);
+    const bool compressed = guess_params.allow_compressed || DirectX::IsCompressed(current_format);
     // provide an alpha channel if there was already one
-    const bool alpha = DirectX::HasAlpha(current_format) || force_alpha == ForceAlpha::Yes;
+    const bool opaque_alpha = guess_params.opaque_alpha;
+    const bool alpha = !opaque_alpha || guess_params.force_alpha;
     if (compressed && alpha)
         return formats.compressed;
     if (compressed)

--- a/tests/tex/formats.cpp
+++ b/tests/tex/formats.cpp
@@ -3,7 +3,6 @@
 #include <catch.hpp>
 
 using btu::tex::BestFormatFor, btu::tex::guess_best_format;
-using enum btu::tex::AllowCompressed;
 
 TEST_CASE("guess_texture_type", "[src]")
 {
@@ -48,38 +47,94 @@ constexpr auto k_best_formats = BestFormatFor{.uncompressed               = DXGI
                                               .compressed                 = DXGI_FORMAT_BC7_UNORM,
                                               .compressed_without_alpha   = DXGI_FORMAT_BC5_UNORM};
 
+using btu::tex::GuessBestFormatArgs;
+
 TEST_CASE("guess_best_format compressed with alpha", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM, k_best_formats, Yes);
-    CHECK(result == DXGI_FORMAT_BC7_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = false,
+                                                        .allow_compressed = true});
+    CHECK(result == k_best_formats.compressed);
+}
+
+TEST_CASE("guess_best_format compressed with opaque alpha", "[src]")
+{
+    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = true});
+    CHECK(result == k_best_formats.compressed_without_alpha);
 }
 
 TEST_CASE("guess_best_format compressed without alpha", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_BC5_UNORM, k_best_formats, Yes);
-    CHECK(result == DXGI_FORMAT_BC5_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_BC5_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = true});
+    CHECK(result == k_best_formats.compressed_without_alpha);
 }
 
 TEST_CASE("guess_best_format uncompressed with alpha", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM, k_best_formats, No);
-    CHECK(result == DXGI_FORMAT_R8G8B8A8_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = false,
+                                                        .allow_compressed = false});
+    CHECK(result == k_best_formats.uncompressed);
+}
+
+TEST_CASE("guess_best_format uncompressed with opaque alpha", "[src]")
+{
+    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = false});
+    CHECK(result == k_best_formats.uncompressed_without_alpha);
 }
 
 TEST_CASE("guess_best_format uncompressed without alpha", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_R8G8_B8G8_UNORM, k_best_formats, No);
-    CHECK(result == DXGI_FORMAT_R8G8_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_R8G8_B8G8_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = false});
+    CHECK(result == k_best_formats.uncompressed_without_alpha);
 }
 
 TEST_CASE("guess_best_format already compressed with allow compressed no", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM, k_best_formats, No);
-    CHECK(result == DXGI_FORMAT_BC7_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = false,
+                                                        .allow_compressed = false});
+    CHECK(result == k_best_formats.compressed);
+}
+
+TEST_CASE("guess_best_format already compressed with opaque alpha and allow compressed no", "[src]")
+{
+    auto result = guess_best_format(DXGI_FORMAT_BC3_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = false});
+    CHECK(result == k_best_formats.compressed_without_alpha);
 }
 
 TEST_CASE("guess_best_format non compressed with allow compressed yes", "[src]")
 {
-    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM, k_best_formats, Yes);
-    CHECK(result == DXGI_FORMAT_BC7_UNORM);
+    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = false,
+                                                        .allow_compressed = true});
+    CHECK(result == k_best_formats.compressed);
+}
+
+TEST_CASE("guess_best_format non compressed with opaque alpha and allow compressed yes", "[src]")
+{
+    auto result = guess_best_format(DXGI_FORMAT_R8G8B8A8_UNORM,
+                                    k_best_formats,
+                                    GuessBestFormatArgs{.opaque_alpha     = true,
+                                                        .allow_compressed = true});
+    CHECK(result == k_best_formats.compressed_without_alpha);
 }


### PR DESCRIPTION
The algorithm for selection which format to output for texture had two issues:

1) Bad compression formats set for older games. BC5 is not supported at all. BC1 should be used in situations where the input has no alpha. Using BC5 is possible, but increases the file size for no reason. Another reason is that introducing alpha to a previously RGB image affects and breaks i.e. normal maps, for which alpha governs the specularity.

2) The selection of the correct format to used based on alpha didn't work - it checked the input *format*, not whether it has alpha or not (the alpha is opaque).

This PR solves both of those issues.