### PR TITLE
feat(tex): improve texture optimization

### DIFF
--- a/tests/tex/optimize.cpp
+++ b/tests/tex/optimize.cpp
@@ -17,6 +17,49 @@ auto operator<<(std::ostream &os, const btu::tex::OptimizationSteps &s) -> std::
               << ";mips: " << s.mipmaps << "; resize x:" << dim.w << " y:" << dim.h;
 }
 
+const auto no_explicit_sets = []() noexcept {
+    auto sets          = btu::tex::Settings::get(btu::Game::SSE);
+    sets.output_format = btu::tex::BestFormatFor{
+        .uncompressed               = DXGI_FORMAT_R8G8B8A8_UNORM,
+        .uncompressed_without_alpha = DXGI_FORMAT_B8G8R8X8_UNORM,
+        .compressed                 = DXGI_FORMAT_BC7_UNORM,
+        .compressed_without_alpha   = DXGI_FORMAT_BC5_UNORM,
+    };
+    sets.use_format_whitelist = false;
+    sets.compress             = false;
+    sets.mipmaps              = false;
+    sets.resize               = std::monostate{};
+    return sets;
+}();
+
+const auto resize_sets = []() noexcept {
+    auto sets   = no_explicit_sets;
+    sets.resize = btu::tex::util::ResizeRatio{.ratio = 7, .min = {128, 128}};
+    return sets;
+}();
+
+const auto mipmaps_sets = []() noexcept {
+    auto sets    = no_explicit_sets;
+    sets.mipmaps = true;
+    return sets;
+}();
+
+const auto compress_whitelist_mips_resize_sets = []() noexcept {
+    auto sets                 = no_explicit_sets;
+    sets.use_format_whitelist = true;
+    sets.allowed_formats      = {DXGI_FORMAT_BC7_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM};
+    sets.compress             = true;
+    sets.mipmaps              = true;
+    sets.resize               = btu::tex::util::ResizeRatio{.ratio = 7, .min = {128, 128}};
+    return sets;
+}();
+
+const auto landscape_sets = [] {
+    auto sets               = no_explicit_sets;
+    sets.landscape_textures = {u8"landscape/file.dds"};
+    return sets;
+}();
+
 constexpr auto bc5_512_no_mips_meta = [] {
     return DirectX::TexMetadata{
         .width      = 512,
@@ -31,35 +74,15 @@ constexpr auto bc5_512_no_mips_meta = [] {
     };
 }();
 
-auto generate_tex(const DirectX::TexMetadata &info) -> btu::tex::Texture
-{
-    auto image    = DirectX::ScratchImage{};
-    const auto hr = image.Initialize(info);
-    REQUIRE(SUCCEEDED(hr));
-    auto tex = btu::tex::Texture{};
-    tex.set(std::move(image));
-
-    return tex;
-}
-
-const auto compress_whitelist_mips_resize_sets = []() noexcept {
-    auto sets                 = btu::tex::Settings::get(btu::Game::SSE);
-    sets.use_format_whitelist = true;
-    sets.output_format        = btu::tex::BestFormatFor{
-               .uncompressed               = DXGI_FORMAT_R8G8B8A8_UNORM,
-               .uncompressed_without_alpha = DXGI_FORMAT_P8,
-               .compressed                 = DXGI_FORMAT_BC1_UNORM,
-               .compressed_without_alpha   = DXGI_FORMAT_BC5_UNORM,
-    };
-    sets.allowed_formats = {DXGI_FORMAT_BC7_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM};
-    sets.compress        = true;
-    sets.mipmaps         = true;
-    sets.resize          = btu::tex::util::ResizeRatio{.ratio = 7, .min = {128, 128}};
-    return sets;
-}();
-
 constexpr auto r8g8b8a8_512_no_mips_meta = [] {
     auto info   = bc5_512_no_mips_meta;
+    info.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    return info;
+}();
+
+constexpr auto r8g8b8a8_512_with_mips_meta = [] {
+    auto info   = bc5_512_no_mips_meta;
+    info.mipLevels = 4;
     info.format = DXGI_FORMAT_R8G8B8A8_UNORM;
     return info;
 }();
@@ -70,18 +93,10 @@ constexpr auto bc7_512_no_mips_meta = [] {
     return info;
 }();
 
-const auto landscape_sets = [] {
-    auto sets                 = compress_whitelist_mips_resize_sets;
-    sets.use_format_whitelist = false;
-    sets.compress             = false;
-    sets.mipmaps              = false;
-    sets.resize               = std::monostate{};
-    sets.landscape_textures   = {u8"landscape/file.dds"};
-    return sets;
-}();
-
 void add_opaque_alpha(DirectX::ScratchImage &tex)
 {
+    REQUIRE(!DirectX::IsCompressed(tex.GetMetadata().format));
+
     // We create a texture with opaque alpha
     constexpr auto transform = [](DirectX::XMVECTOR *out_pixels,
                                   const DirectX::XMVECTOR *,
@@ -100,12 +115,31 @@ void add_opaque_alpha(DirectX::ScratchImage &tex)
     tex = std::move(timage);
 }
 
-[[nodiscard]] auto generate_landscape_texture(DirectX::TexMetadata meta) -> btu::tex::Texture
+auto generate_tex(const DirectX::TexMetadata &info) -> btu::tex::Texture
+{
+    auto image = DirectX::ScratchImage{};
+
+    auto hr = image.Initialize(info);
+    REQUIRE(SUCCEEDED(hr));
+
+    auto tex = btu::tex::Texture{};
+    tex.set(std::move(image));
+
+    return tex;
+}
+
+[[nodiscard]] auto generate_opaque_tex(DirectX::TexMetadata meta) -> btu::tex::Texture
 {
     auto tex = generate_tex(meta);
     // if format does not have alpha, it's already opaque
     if (DirectX::HasAlpha(meta.format))
         add_opaque_alpha(tex.get());
+    return tex;
+}
+
+[[nodiscard]] auto generate_landscape_tex(DirectX::TexMetadata meta) -> btu::tex::Texture
+{
+    auto tex = generate_opaque_tex(meta);
     tex.set_load_path(u8"textures/landscape/file.dds");
     return tex;
 }
@@ -126,13 +160,13 @@ TEST_CASE("compute_optimization_steps", "[src]")
     }
     SECTION("landscape texture")
     {
-        auto tex = generate_landscape_texture(r8g8b8a8_512_no_mips_meta);
+        auto tex = generate_landscape_tex(r8g8b8a8_512_no_mips_meta);
 
         auto res = compute_optimization_steps(tex, landscape_sets);
         CHECK(res.resize == std::nullopt);
         CHECK(res.add_transparent_alpha);
         CHECK_FALSE(res.mipmaps);
-        CHECK(res.best_format == landscape_sets.output_format.compressed);
+        CHECK(res.best_format == landscape_sets.output_format.uncompressed);
         CHECK_FALSE(res.convert);
     }
     SECTION("do not compress to same format as current")
@@ -162,7 +196,7 @@ TEST_CASE("compute_optimization_steps", "[src]")
     }
     SECTION("best_format has alpha if add_transparent_alpha, even on texture without alpha")
     {
-        auto tex = generate_landscape_texture(bc5_512_no_mips_meta);
+        auto tex = generate_landscape_tex(bc5_512_no_mips_meta);
 
         const auto res = compute_optimization_steps(tex, landscape_sets);
         CHECK(res.resize == std::nullopt);
@@ -171,14 +205,87 @@ TEST_CASE("compute_optimization_steps", "[src]")
         CHECK(res.best_format == landscape_sets.output_format.compressed);
         CHECK_FALSE(res.convert);
     }
+    SECTION("nothing to do for texture without alpha")
+    {
+        auto tex  = generate_opaque_tex(r8g8b8a8_512_no_mips_meta);
+        auto sets = no_explicit_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize == std::nullopt);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK_FALSE(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.uncompressed_without_alpha);
+        CHECK_FALSE(res.convert);
+    }
+    SECTION("nothing to do for texture with alpha")
+    {
+        auto tex  = generate_tex(r8g8b8a8_512_no_mips_meta);
+        auto sets = no_explicit_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize == std::nullopt);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK_FALSE(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.uncompressed);
+        CHECK_FALSE(res.convert);
+    }
+    SECTION("nothing to do for compressed texture")
+    {
+        auto tex  = generate_tex(bc7_512_no_mips_meta);
+        auto sets = no_explicit_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize == std::nullopt);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK_FALSE(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.compressed);
+        CHECK_FALSE(res.convert);
+    }
+    SECTION("resizing texture without alpha keeps a format without alpha")
+    {
+        auto tex    = generate_opaque_tex(r8g8b8a8_512_no_mips_meta);
+        auto sets   = resize_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK_FALSE(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.uncompressed_without_alpha);
+        CHECK_FALSE(res.convert);
+    }
+    SECTION("resizing always keeps mipmaps")
+    {
+        auto tex = generate_tex(r8g8b8a8_512_with_mips_meta);
+        auto sets = resize_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.uncompressed);
+        CHECK_FALSE(res.convert);
+    }
+    SECTION("resizing compressed texture keeps the compression")
+    {
+        auto tex  = generate_tex(bc7_512_no_mips_meta);
+        auto sets = resize_sets;
+
+        const auto res = compute_optimization_steps(tex, sets);
+        CHECK(res.resize);
+        CHECK_FALSE(res.add_transparent_alpha);
+        CHECK_FALSE(res.mipmaps);
+        CHECK(res.best_format == sets.output_format.compressed);
+        CHECK_FALSE(res.convert);
+    }
 }
 
 TEST_CASE("tex_optimize", "[src]")
 {
-    SECTION("bc5_512_no_mips_meta")
+    SECTION("full settings, uncompressed texture without alpha")
     {
-        auto tex   = generate_tex(bc5_512_no_mips_meta);
-        auto steps = compute_optimization_steps(tex, compress_whitelist_mips_resize_sets);
+        auto sets  = compress_whitelist_mips_resize_sets;
+        auto tex   = generate_opaque_tex(r8g8b8a8_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
         auto res   = optimize(std::move(tex), steps, compression_dev);
         REQUIRE(res.has_value());
 
@@ -189,12 +296,144 @@ TEST_CASE("tex_optimize", "[src]")
         CHECK(res_info.depth == 1);
         CHECK(res_info.arraySize == 1);
         CHECK(res_info.mipLevels == 8);
-        CHECK(res_info.format == compress_whitelist_mips_resize_sets.output_format.compressed_without_alpha);
+        CHECK(res_info.format == sets.output_format.compressed_without_alpha);
         CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+    }
+    SECTION("full settings, uncompressed texture with alpha")
+    {
+        auto sets  = compress_whitelist_mips_resize_sets;
+        auto tex   = generate_tex(r8g8b8a8_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 8);
+        CHECK(res_info.format == sets.output_format.compressed);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+    }
+    SECTION("full settings, compressed texture without alpha")
+    {
+        auto sets  = compress_whitelist_mips_resize_sets;
+        auto tex   = generate_tex(bc5_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 8);
+        CHECK(res_info.format == sets.output_format.compressed_without_alpha);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+    }
+    SECTION("full settings, compressed texture with alpha")
+    {
+        auto sets  = compress_whitelist_mips_resize_sets;
+        auto tex   = generate_tex(bc7_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 8);
+        CHECK(res_info.format == sets.output_format.compressed);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+    }
+    SECTION("resize compressed")
+    {
+        auto sets  = resize_sets;
+        auto tex   = generate_tex(bc7_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 1);
+        CHECK(res_info.format == sets.output_format.compressed);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+    }
+    SECTION("resize uncompressed without alpha")
+    {
+        auto sets  = resize_sets;
+        auto tex   = generate_opaque_tex(r8g8b8a8_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 1);
+        CHECK(res_info.format == sets.output_format.uncompressed_without_alpha);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+
+        CHECK(res->get().IsAlphaAllOpaque());
+    }
+    SECTION("resize uncompressed with alpha")
+    {
+        auto sets  = resize_sets;
+        auto tex   = generate_tex(r8g8b8a8_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 128);
+        CHECK(res_info.height == 128);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 1);
+        CHECK(res_info.format == sets.output_format.uncompressed);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+
+        CHECK(!res->get().IsAlphaAllOpaque());
+    }
+    SECTION("mipmaps uncompressed without alpha")
+    {
+        auto sets  = mipmaps_sets;
+        auto tex   = generate_opaque_tex(r8g8b8a8_512_no_mips_meta);
+        auto steps = compute_optimization_steps(tex, sets);
+        auto res   = optimize(std::move(tex), steps, compression_dev);
+        REQUIRE(res.has_value());
+
+        const auto res_info = res->get().GetMetadata();
+
+        CHECK(res_info.width == 512);
+        CHECK(res_info.height == 512);
+        CHECK(res_info.depth == 1);
+        CHECK(res_info.arraySize == 1);
+        CHECK(res_info.mipLevels == 10);
+        CHECK(res_info.format == sets.output_format.uncompressed_without_alpha);
+        CHECK(res_info.dimension == DirectX::TEX_DIMENSION_TEXTURE2D);
+
+        CHECK(res->get().IsAlphaAllOpaque());
     }
     SECTION("landscape texture")
     {
-        auto tex   = generate_landscape_texture(r8g8b8a8_512_no_mips_meta);
+        auto tex   = generate_landscape_tex(r8g8b8a8_512_no_mips_meta);
         auto steps = compute_optimization_steps(tex, landscape_sets);
         auto res   = optimize(std::move(tex), steps, compression_dev);
         REQUIRE(res.has_value());
@@ -213,7 +452,7 @@ TEST_CASE("tex_optimize", "[src]")
     }
     SECTION("fails if output format would remove alpha")
     {
-        auto tex          = generate_landscape_texture(bc5_512_no_mips_meta);
+        auto tex          = generate_landscape_tex(bc5_512_no_mips_meta);
         auto steps        = compute_optimization_steps(tex, landscape_sets);
         steps.best_format = DXGI_FORMAT_BC5_UNORM; // no alpha
         const auto res    = optimize(std::move(tex), steps, compression_dev);
@@ -225,6 +464,8 @@ TEST_CASE("tex_optimize", "[src]")
         auto sets = compress_whitelist_mips_resize_sets;
         // go back to more common settings
         sets.output_format = btu::tex::Settings::get(btu::Game::SSE).output_format;
+        // Change X8 to A8, as X8 is saved and loaded as A8 anyways, just without alpha bits.
+        sets.output_format.uncompressed_without_alpha = DXGI_FORMAT_R8G8B8A8_UNORM;
         sets.resize        = btu::tex::Dimension{128, 128};
         test_expected_dir(u8"optimize", [&](auto &&f) {
             const btu::tex::OptimizationSteps steps = btu::tex::compute_optimization_steps(f, sets);


### PR DESCRIPTION
Introduced some further improvements to the texture optimization process:

1) Do not decompress images when there is no need, that is, when resizing is required.
There is no need for decompressing and compressing an image again if resizing is not applied.
2) Enforce conversion of results when input has no/opaque alpha to a format without alpha (either compressed, or not).
This fixes the issue with `Resize` introducing full white alpha to the image, which can break stuff like normal maps. Normal maps with full white alpha are not the same as those with no alpha (alpha represents specularity).
3) Never remove mipmaps - if resizing is applied and the input had mipmaps, regenerate them after resize.
This is because mipmaps are very important to game visuals and performance. Removing them while resizing doesn't make sense even if mipmaps are not requested.

An important point: recompressing with a "higher" BC does not improve quality. If the input is already block compressed, decompressing does not restore quality, and thus compressing it again with better BC does not improve on the input at all. In fact, it only increased the size of the resulting image without any benefits.