### PR TITLE
feat(tex): add option to ignore files by regex

### DIFF
--- a/include/btu/tex/optimize.hpp
+++ b/include/btu/tex/optimize.hpp
@@ -34,6 +34,8 @@ struct Settings
     BestFormatFor output_format;
 
     std::vector<std::u8string> landscape_textures;
+
+    std::vector<std::u8string> ignored_files;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings,
@@ -44,7 +46,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings,
                                    use_format_whitelist,
                                    allowed_formats,
                                    output_format,
-                                   landscape_textures)
+                                   landscape_textures,
+                                   ignored_files)
 
 struct OptimizationSteps
 {


### PR DESCRIPTION
Add a setting to texture `Settings` that enables ignoring certain file paths completely based on regexes.

Ignore interface and LOD textures for FNV by default, rest of game presets left untouched.

A similar thing could definitely be accomplished by CAO patterns. That however would require tying settings from bethutils with patterns with CAO, which with their current state I am not fully comfortable doing.